### PR TITLE
Awsrequests replace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # C extensions
 *.so
@@ -80,6 +81,7 @@ celerybeat-schedule
 
 # dotenv
 .env
+.env*
 
 # virtualenv
 venv/
@@ -90,3 +92,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# VS Code
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ ENV/
 
 # VS Code
 .vscode/
+
+# integration tests
+tests/*_int.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '2.7'
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ deploy:
   on:
     tags: true
     branch: master
+  skip_existing: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install .
   - pip install -r requirements_dev.txt
 script:
-  - python setup.py test -m unit
+  - python setup.py test
 deploy:
   provider: pypi
   user: cleardataeng

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ python:
   - '3.3'
   - '3.4'
   - '3.5'
+  - '3.6'
+  - '3.7'
 install:
   - pip install .
   - pip install -r requirements_dev.txt
 script:
-  - python setup.py test
+  - python setup.py test -m unit
 deploy:
   provider: pypi
   user: cleardataeng

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
-python:
-  - '2.7'
-  - '3.4'
-  - '3.5'
-  - '3.6'
-  - '3.7'
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - pip install .
   - pip install -r requirements_dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,19 @@ install:
 script:
   - python setup.py test
 deploy:
-  provider: pypi
-  user: cleardataeng
-  password:
-    secure: JSOx9ZOXWmXrP1NvaSVZUB1OeEy93f5jOctj0hdG0mitB3eKCGCeHZN4XHHwNGd3gvFzAod9Q6ZZjC+JB/ccVwVP6wDL4y8QauxlAQLUxsAWv6Vs0fR4SX+Kf8C9pYcVVxQWEXRxW+Tq7x56UzyTGBCIsSdMsw0PJ9XeZXBJrbfmAO0NrrZOQ5U8SVEpaiYjshM3SE+UNwlFuwdfw5xvchUUPF8b4NZdVSjmbtVt88VgrwnkQI5r0DG347cPcj7D+x/+jQpvTn7QkBvLOGQLuJP9OwUbJBYm6vupZAYDZR0XNodOLjBbu2hbDWELKiirG5gzg+vbnFnD84A4P1vYE6tfatpepkfLaqdl26fIMeDUuFB+WuxAuN9ID311JeY1Np+6FIi0qbbOBv2ROOt3mV1Ul7W0EBmEfg8N1ja77c7jnfBsGgMn+1l0wXX0Vbo1oAb5QyFjoAynh0Y0Eegcm3eW2tc/nij75G1SAWzC2gl5l9xxBpmy7pCX1YihxbAnzDU9MYZxPMa6PZEgSkrqePSAIVNVCncoJtpxSTPRjT7Nz4rAdFseQDidL98HfQYf0FPRRfeEuAF3EgXC0vv9hafXJyVtlGXbJEqWebRM3DHE9gGBr9g/6rGV2TGEjsIkgRsI2LlxqLEP6V9a7d+wwisWgzP6N/D7GMjL60rIrRI=
-  on:
-    tags: true
-    branch: master
-  skip_existing: true
+  - provider: pypi
+    user: cleardataeng
+    password:
+        secure: JSOx9ZOXWmXrP1NvaSVZUB1OeEy93f5jOctj0hdG0mitB3eKCGCeHZN4XHHwNGd3gvFzAod9Q6ZZjC+JB/ccVwVP6wDL4y8QauxlAQLUxsAWv6Vs0fR4SX+Kf8C9pYcVVxQWEXRxW+Tq7x56UzyTGBCIsSdMsw0PJ9XeZXBJrbfmAO0NrrZOQ5U8SVEpaiYjshM3SE+UNwlFuwdfw5xvchUUPF8b4NZdVSjmbtVt88VgrwnkQI5r0DG347cPcj7D+x/+jQpvTn7QkBvLOGQLuJP9OwUbJBYm6vupZAYDZR0XNodOLjBbu2hbDWELKiirG5gzg+vbnFnD84A4P1vYE6tfatpepkfLaqdl26fIMeDUuFB+WuxAuN9ID311JeY1Np+6FIi0qbbOBv2ROOt3mV1Ul7W0EBmEfg8N1ja77c7jnfBsGgMn+1l0wXX0Vbo1oAb5QyFjoAynh0Y0Eegcm3eW2tc/nij75G1SAWzC2gl5l9xxBpmy7pCX1YihxbAnzDU9MYZxPMa6PZEgSkrqePSAIVNVCncoJtpxSTPRjT7Nz4rAdFseQDidL98HfQYf0FPRRfeEuAF3EgXC0vv9hafXJyVtlGXbJEqWebRM3DHE9gGBr9g/6rGV2TGEjsIkgRsI2LlxqLEP6V9a7d+wwisWgzP6N/D7GMjL60rIrRI=
+    skip_existing: true
+    on:
+        tags: true
+        branch: master
+  - provider: pypi
+    user: cleardataeng
+    server: https://test.pypi.org/legacy/
+    password:
+        secure: fA9iLQFAVYW2s55Vb6OOVcvhQwUA+YvKOMH4r5qSL3O54BitZNdHGyD7zDTp4WU0UPX+PKEhVN7g8Wp2ULd3bKYWP2JKuuOlzzTRuohHVNdmOEYaMLRyt+3dDG3RxU8ABFfdt7vrH9DVhSnvchS2tYGkv1OgjOY9BA0C9rgEA/g3iUWcpZdZs24fV3oxPHvWqaVZrm+G5Jo5fs4/E79OFDKCZWNoFMx5DsRmDvpmTc76uvGMstxE2YGNZEVZF55WKnZXOcX3Ee7++EIso0MECEXhamlyZ6O8U/YHqBArLqEBSjbIcRzKV3kmxzYdfB0rXdt10poh2Gb93HjeY5T7oFDLKzEvU13a6GhXZ6/rd32ImWdq2i0olsx/+FrTtcLXB1tH8Gpzt8NVTxqYii1FUwMv4gCdnPJm9uXJMNU1jJjWNFaAuutQCIuV2kQ9sxevSWhxLUqYCR+zHSL2exJET23Zj2pmgdpmVbops5IL96Au74P2TrmYJ3DZr1tCZW9s0KZBbw/Nrb16FjZs6ccR0tCjGSWsxpzOWprxA7R0YFkwitCzJm6Hh0QPwQQy+JjSJ8fNNaYImEbacq7TZBIURI2rGK/f3FQEeSvaxBuQeBQ04P/b6GKNbEXwoIbEVE80V7y/PblAaD1v1+ZszHd6ja1KOr1hWDGCC+8HtOj72jY=
+    skip_existing: true
+    on:
+        branch: develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - '2.7'
+  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'

--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,6 @@ endif
 
 test: ## run tests quickly with the default Python
 	python setup.py test
+
+tox:
+	tox -p 2 -o

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endef
 export BROWSER_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
-clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+clean: clean-test clean-build clean-pyc ## remove all build, test, coverage and Python artifacts
 
 clean-build: ## remove build artifacts
 	rm -fr build/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-awsrequests==0.0.12
-boto3==1.4.7
+requests-sigv4==0.1.0
+boto3==1.9.102
 cachetools==2.0.1
 figgypy==1.1.7
-future==0.16.0
-requests==2.18.4
+future==0.17.1
+requests==2.21.0
 retrying==1.3.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 coverage>=4.1
 docutils==0.14
 flake8>=2.6.0
+freezegun
 pip>=8.1.2
 tox>=2.3.1
 Sphinx>=1.4.4

--- a/seshypy/base_session.py
+++ b/seshypy/base_session.py
@@ -91,8 +91,9 @@ class BaseSession(object):
             try:
                 return not inspect.isfunction(method.cache_info)
             except AttributeError:
-                setattr(self, method_name, safe_ttl_cache(
-                    ttl=self.cache_ttl)(method))
+                setattr(
+                    self, method_name,
+                    safe_ttl_cache(ttl=self.cache_ttl)(method))
                 return True
         except AttributeError:
             # method doesn't exist on initializing class

--- a/seshypy/base_session.py
+++ b/seshypy/base_session.py
@@ -3,7 +3,7 @@ import logging
 try:
     from urllib.parse import urlencode
     from urllib.parse import urljoin
-except ImportError: # Python 2
+except ImportError:  # Python 2
     from urllib import urlencode
     from urlparse import urljoin
 
@@ -54,6 +54,7 @@ class BaseSession(object):
     .. _cachetools:
         http://pythonhosted.org/cachetools/
     """
+
     def __init__(self, host, role_arn=None, aws_access_key_id=None,
                  aws_secret_access_key=None, region=None, session=None,
                  use_cache=True, cache_ttl=1200, cache_methods=None):
@@ -63,8 +64,11 @@ class BaseSession(object):
             'Content-type': 'application/json',
         }
         if not session:
-            session = Session(role_arn=role_arn, aws_access_key_id=aws_access_key_id,
-                              aws_secret_access_key=aws_secret_access_key, region=region)
+            session = Session(
+                role_arn=role_arn,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                region=region)
         self.session = session
         self.__use_cache = bool(use_cache)
         self.__cache_ttl = cache_ttl
@@ -87,7 +91,8 @@ class BaseSession(object):
             try:
                 return not inspect.isfunction(method.cache_info)
             except AttributeError:
-                setattr(self, method_name, safe_ttl_cache(ttl=self.cache_ttl)(method))
+                setattr(self, method_name, safe_ttl_cache(
+                    ttl=self.cache_ttl)(method))
                 return True
         except AttributeError:
             # method doesn't exist on initializing class
@@ -133,11 +138,13 @@ class BaseSession(object):
         url = urljoin(host, path)
         try:
             if method == 'POST':
-                res = req.post(url, headers=headers, json=payload, params=params)
+                res = req.post(url, headers=headers,
+                               json=payload, params=params)
             elif method == 'GET':
                 res = req.get(url, headers=headers, params=params)
             elif method == 'PUT':
-                res = req.put(url, headers=headers, params=params, json=payload)
+                res = req.put(url, headers=headers,
+                              params=params, json=payload)
             elif method == 'DELETE':
                 res = req.delete(url, headers=headers)
             else:
@@ -243,7 +250,8 @@ class BaseSession(object):
             }
             session.api_retrying(**retrying_kwargs)
         """
-        self.make_api_gateway_call = retry(*args, **kwargs)(self.make_api_gateway_call)
+        self.make_api_gateway_call = retry(
+            *args, **kwargs)(self.make_api_gateway_call)
 
     def __enter__(self):
         return self

--- a/seshypy/session.py
+++ b/seshypy/session.py
@@ -186,8 +186,7 @@ class Session(object):
                 service = method.__self__.__class__.__name__.lower()
                 client = self.__client(service)
             except UnknownServiceError:
-                service = method.__self__.__class__.__name__.split('.')[
-                    0].lower()
+                service = method.__self__.__class__.__name__.split('.')[0].lower()
                 resource = self.__resource(service)
             try:
                 return getattr(client, method.__name__)(*args, **kwargs)

--- a/seshypy/session.py
+++ b/seshypy/session.py
@@ -87,9 +87,9 @@ class Session(object):
     def _verify_resolved(self):
         """Verify or update resolved credentials."""
         if (
-            self.resolved
-            and self.resolved is RefreshableCredentials
-            and self.resolved.refresh_needed()
+            self.resolved and
+            self.resolved is RefreshableCredentials and
+            self.resolved.refresh_needed()
         ):
             self._resolve()
 

--- a/seshypy/session.py
+++ b/seshypy/session.py
@@ -1,9 +1,8 @@
 from datetime import datetime, timedelta
 import functools
 import inspect
-import logging
 
-from awsrequests import AwsRequester
+from requests_sigv4 import Sigv4Request
 import boto3
 import botocore
 from botocore.credentials import RefreshableCredentials
@@ -13,11 +12,16 @@ from dateutil.tz import tzutc
 
 class Session(object):
     """AWS Session for CMDB access."""
-    def __init__(self, role_arn=None, aws_access_key_id=None,
-                 aws_secret_access_key=None, region=None):
+
+    def __init__(
+        self,
+        role_arn=None,
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+        region=None,
+    ):
         self.region = region
         self.role_arn = role_arn
-
         self.assumed = None
         self.passed = None
         self.resolved = None
@@ -25,7 +29,8 @@ class Session(object):
             self.passed = {'access_key': aws_access_key_id,
                            'secret_key': aws_secret_access_key}
         elif any([aws_access_key_id, aws_secret_access_key]):
-            raise ValueError('must provide both aws_access_key_id and aws_secret_key or neither')
+            raise ValueError(
+                'must provide both aws_access_key_id and aws_secret_key or neither')
         else:
             self._resolve()
 
@@ -81,9 +86,12 @@ class Session(object):
 
     def _verify_resolved(self):
         """Verify or update resolved credentials."""
-        if self.resolved:
-            if (self.resolved is RefreshableCredentials) and self.resolved.refresh_needed():
-                self._resolve()
+        if (
+            self.resolved
+            and self.resolved is RefreshableCredentials
+            and self.resolved.refresh_needed()
+        ):
+            self._resolve()
 
     def requests(self):
         """Return requester for other sessions."""
@@ -92,20 +100,22 @@ class Session(object):
         if self.assumed:
             reset_time = datetime.now(tz=tzutc()) + timedelta(seconds=30)
             if self.assumed['Credentials']['Expiration'] < reset_time:
-
                 self.assumed = self._assume_role()
+
             kwargs['access_key'] = self.assumed['Credentials']['AccessKeyId']
             kwargs['secret_key'] = self.assumed['Credentials']['SecretAccessKey']
             kwargs['session_token'] = self.assumed['Credentials']['SessionToken']
             kwargs['session_expires'] = self.assumed['Credentials']['Expiration']
-            return AwsRequester(**kwargs)
+            return Sigv4Request(**kwargs)
+
         kwargs['access_key'] = (self.passed['access_key']
                                 if self.passed else self.resolved.access_key)
         kwargs['secret_key'] = (self.passed['secret_key']
                                 if self.passed else self.resolved.secret_key)
         if self.resolved:
             kwargs['session_token'] = self.resolved.token
-        return AwsRequester(**kwargs)
+
+        return Sigv4Request(**kwargs)
 
     def __boto3_kwargs(self):
         """Get boto3 client or resource kwargs."""
@@ -119,6 +129,7 @@ class Session(object):
             kwargs['aws_secret_access_key'] = self.assumed['Credentials']['SecretAccessKey']
             kwargs['aws_session_token'] = self.assumed['Credentials']['SessionToken']
             return kwargs
+
         kwargs['aws_access_key_id'] = (
             self.passed['access_key']
             if self.passed else self.resolved.access_key
@@ -175,7 +186,8 @@ class Session(object):
                 service = method.__self__.__class__.__name__.lower()
                 client = self.__client(service)
             except UnknownServiceError:
-                service = method.__self__.__class__.__name__.split('.')[0].lower()
+                service = method.__self__.__class__.__name__.split('.')[
+                    0].lower()
                 resource = self.__resource(service)
             try:
                 return getattr(client, method.__name__)(*args, **kwargs)

--- a/seshypy/version.py
+++ b/seshypy/version.py
@@ -1,1 +1,2 @@
-VERSION = '0.6.dev'
+"""Package version will be written by setup.py."""
+VERSION = 'undefined'

--- a/seshypy/version.py
+++ b/seshypy/version.py
@@ -1,2 +1,1 @@
-"""Package version will be written by setup.py."""
-VERSION = 'undefined'
+VERSION = '0.6.dev'

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ exclude=docs
 
 [wheel]
 universal = 1
+
+[tool:pytest]
+addopts = -m unit

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 install_requires = [
-    'awsrequests>=0.0.5',
+    'requests-sigv4>=0.1.0',
     'cachetools>=1.1.6',
     'figgypy>=0.2.0',
     'future',
@@ -30,6 +30,6 @@ setup(
     install_requires=install_requires,
     setup_requires=['pytest-runner'],
     tests_require=[
-        'pytest'
+        'pytest', 'freezegun'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,18 @@ setup(
     tests_require=[
         'pytest',
         'freezegun',
-    ]
+    ],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 install_requires = [
-    'requests-sigv4>=0.1.0',
+    'requests-sigv4>=0.1.4',
     'cachetools>=1.1.6',
     'figgypy>=0.2.0',
     'future',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'future',
     'requests>=2.21.0',
     'retrying>=1.3.3',
-    'setuptools'
+    'setuptools>=36.5.0'
 ]
 
 setup(
@@ -30,6 +30,7 @@ setup(
     install_requires=install_requires,
     setup_requires=['pytest-runner'],
     tests_require=[
-        'pytest', 'freezegun'
+        'pytest',
+        'freezegun',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'cachetools>=1.1.6',
     'figgypy>=0.2.0',
     'future',
-    'requests>=2.7.0',
+    'requests>=2.21.0',
     'retrying>=1.3.3',
     'setuptools>=36.5.0'
 ]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'future',
     'requests>=2.21.0',
     'retrying>=1.3.3',
-    'setuptools>=36.5.0'
+    'setuptools'
 ]
 
 setup(

--- a/tests/test_base_session.py
+++ b/tests/test_base_session.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import os
+import sys
 import unittest
 
 from freezegun import freeze_time
@@ -29,7 +30,10 @@ class TestBaseSession(unittest.TestCase):
             'headers': {
                 'Accept': 'application/json',
                 'Accept-Encoding': 'identity',
-                'Authorization': 'AWS4-HMAC-SHA256 Credential=test/20200202/us-west-2/execute-api/aws4_request, SignedHeaders=host;x-amz-date, Signature=db7be03c558c367efbd8cf9d587a6e224e8380595801586fdeee3223560d7fc4',
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=test/20200202/'
+                'us-west-2/execute-api/aws4_request, SignedHeaders=host;'
+                'x-amz-date, Signature=db7be03c558c367efbd8cf9d587a6e224'
+                'e8380595801586fdeee3223560d7fc4',
                 'Content-Type': 'application/json',
                 'Host': 'httpbin.org',
                 'X-Amz-Date': '20200202T000000Z',
@@ -42,46 +46,11 @@ class TestBaseSession(unittest.TestCase):
         res = session.get(
             path='/get',
         )
-        got = json.loads(str(res.content))
+        if sys.version_info[0] == 2:
+            got = json.loads(res.content)
+        else:
+            got = json.loads(res.content.decode())
         got.pop('origin', None)
-        assert got == want
-
-
-@pytest.mark.integration
-class TestBaseSessionIntegration(unittest.TestCase):
-    @classmethod
-    def setup_class(cls):
-        os.environ['AWS_REGION'] = 'us-west-2'
-
-    def test_base_session_get(self):
-        want = {
-            'id': 1234, 'type': 'dog', 'price': 249.99
-        }
-        session = BaseSession(
-            host='https://znlmeqqrf5.execute-api.us-west-2.amazonaws.com',
-            region='us-west-2',
-        )
-        res = session.get(
-            path='/testing/pets/1234',
-            params={'id': 12345}
-        )
-        got = json.loads(res.content)
-        assert got == want
-
-    def test_base_session_post(self):
-        want = {'pet': {'type': 'cat', 'price': 9.99}, 'message': 'success'}
-        session = BaseSession(
-            host='https://znlmeqqrf5.execute-api.us-west-2.amazonaws.com',
-            region='us-west-2',
-        )
-        res = session.post(
-            path='/testing/pets',
-            payload={
-                'type': 'cat',
-                'price': 9.99,
-            }
-        )
-        got = json.loads(res.content)
         assert got == want
 
 

--- a/tests/test_base_session.py
+++ b/tests/test_base_session.py
@@ -42,7 +42,7 @@ class TestBaseSession(unittest.TestCase):
         res = session.get(
             path='/get',
         )
-        got = json.loads(res.content)
+        got = json.loads(str(res.content))
         got.pop('origin', None)
         assert got == want
 

--- a/tests/test_base_session.py
+++ b/tests/test_base_session.py
@@ -1,10 +1,88 @@
+import json
+import pytest
 import os
 import unittest
 
+from freezegun import freeze_time
 
+from seshypy.base_session import BaseSession
+
+
+@pytest.mark.unit
 class TestBaseSession(unittest.TestCase):
-    def test_base_session(self):
-        self.assertTrue(True)
+    @classmethod
+    def setup_class(cls):
+        os.environ['AWS_ACCESS_KEY_ID'] = 'test'
+        os.environ['AWS_DEFAULT_REGION'] = 'us-west-2'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'test'
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ.pop('AWS_DEFAULT_REGION', None)
+        os.environ.pop('AWS_SECRET_ACCESS_KEY', None)
+        os.environ.pop('AWS_ACCESS_KEY_ID', None)
+
+    @freeze_time('2020-02-02')
+    def test_base_session_get(self):
+        want = {
+            'args': {},
+            'headers': {
+                'Accept': 'application/json',
+                'Accept-Encoding': 'identity',
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=test/20200202/us-west-2/execute-api/aws4_request, SignedHeaders=host;x-amz-date, Signature=db7be03c558c367efbd8cf9d587a6e224e8380595801586fdeee3223560d7fc4',
+                'Content-Type': 'application/json',
+                'Host': 'httpbin.org',
+                'X-Amz-Date': '20200202T000000Z',
+            },
+            'url': 'https://httpbin.org/get'
+        }
+        session = BaseSession(
+            host='https://httpbin.org'
+        )
+        res = session.get(
+            path='/get',
+        )
+        got = json.loads(res.content)
+        got.pop('origin', None)
+        assert got == want
+
+
+@pytest.mark.integration
+class TestBaseSessionIntegration(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        os.environ['AWS_REGION'] = 'us-west-2'
+
+    def test_base_session_get(self):
+        want = {
+            'id': 1234, 'type': 'dog', 'price': 249.99
+        }
+        session = BaseSession(
+            host='https://znlmeqqrf5.execute-api.us-west-2.amazonaws.com',
+            region='us-west-2',
+        )
+        res = session.get(
+            path='/testing/pets/1234',
+            params={'id': 12345}
+        )
+        got = json.loads(res.content)
+        assert got == want
+
+    def test_base_session_post(self):
+        want = {'pet': {'type': 'cat', 'price': 9.99}, 'message': 'success'}
+        session = BaseSession(
+            host='https://znlmeqqrf5.execute-api.us-west-2.amazonaws.com',
+            region='us-west-2',
+        )
+        res = session.post(
+            path='/testing/pets',
+            payload={
+                'type': 'cat',
+                'price': 9.99,
+            }
+        )
+        got = json.loads(res.content)
+        assert got == want
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,8 @@ deps =
     pytest
     pytest-runner
     freezegun
+commands_pre =
+    pip install -U pip
+    pip install -U --ignore-installed setuptools
 commands =
     python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,py37
+envlist = py27,py34,py35,py36,py37
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27,py33,py34,py35,py36,py37
+
+[testenv]
+deps =
+    pytest
+    pytest-runner
+    freezegun
+commands =
+    python setup.py test


### PR DESCRIPTION
- Switches out the old awsrequests library for the new signing library that does sigv4 with boto.  
- Updated Travis CI to support up to python 3.7.
- Removed python 3.3, as setup tools does not support this version, at least pypi indicates this is the case. And 3.3 builds were failing.